### PR TITLE
Open searched file in vim instead of gvim

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -42,7 +42,7 @@ alias la='ls -A'
 alias l='ls -CF'
 
 function op() {
-  gvim -p `find . -name "$1"`
+  vim -p `find . -name "$1"`
 }
 
 function g() {


### PR DESCRIPTION
- gvim is not always installed on machines so attempt to open in vim instead of gvim
- vim can be replaced with gvim if machine has gvim installed and required